### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,9 +11,6 @@
 		"authorList": ["Dyonovan"],
 		"credits": "Azanor for Thaumcraft. Dominance28 for textures.",
 		"logoFile": "assets/tcnodetracker/textures/gui/arrow.png",
-		"screenshots": [],
-		"requiredMods": ["Forge@[10.12.1.1112,)", "Thaumcraft"],
-		"dependencies": ["Thaumcraft"],
-		"useDependencyInformation": true
+		"screenshots": []
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.