### PR TITLE
Add cleanup of TC files on world deletion & Refactor some Path handling

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.57:dev")
     compileOnly("com.github.GTNewHorizons:Navigator:1.1.2:dev")
     runtimeOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")

--- a/src/main/java/com/dyonovan/tcnodetracker/TCNodeTracker.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/TCNodeTracker.java
@@ -13,6 +13,7 @@ import com.dyonovan.tcnodetracker.bindings.KeyBindings;
 import com.dyonovan.tcnodetracker.events.ClientConnectionEvent;
 import com.dyonovan.tcnodetracker.events.KeyInputEvent;
 import com.dyonovan.tcnodetracker.events.RightClickEvent;
+import com.dyonovan.tcnodetracker.events.SaveDeletionEvent;
 import com.dyonovan.tcnodetracker.gui.GuiPointer;
 import com.dyonovan.tcnodetracker.handlers.ConfigHandler;
 import com.dyonovan.tcnodetracker.integration.navigator.NavigatorIntegration;
@@ -58,6 +59,7 @@ public class TCNodeTracker {
         ConfigHandler.init(event.getSuggestedConfigurationFile());
 
         MinecraftForge.EVENT_BUS.register(new RightClickEvent());
+        MinecraftForge.EVENT_BUS.register(new SaveDeletionEvent());
         FMLCommonHandler.instance().bus().register(new ClientConnectionEvent());
         FMLCommonHandler.instance().bus().register(new KeyInputEvent());
     }

--- a/src/main/java/com/dyonovan/tcnodetracker/TCNodeTracker.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/TCNodeTracker.java
@@ -1,5 +1,6 @@
 package com.dyonovan.tcnodetracker;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +43,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class TCNodeTracker {
 
     public static Logger LOGGER = LogManager.getLogger(Constants.MODID);
-    public static String hostName;
+    public static Path jsonPath;
     public static ArrayList<NodeList> nodelist = new ArrayList<>();
     public static boolean doGui = false;
     public static int xMarker, yMarker, zMarker;

--- a/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
@@ -7,6 +7,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.server.integrated.IntegratedServer;
 
 import com.dyonovan.tcnodetracker.TCNodeTracker;
+import com.dyonovan.tcnodetracker.lib.Constants;
 import com.dyonovan.tcnodetracker.lib.JsonUtils;
 import com.dyonovan.tcnodetracker.lib.Utils;
 
@@ -24,7 +25,7 @@ public class ClientConnectionEvent {
 
             InetSocketAddress address = (InetSocketAddress) event.manager.getSocketAddress();
             hostname = address.getHostName() + "_" + address.getPort();
-            hostname = Utils.invalidChars(hostname);;
+            hostname = Utils.invalidChars(hostname);
 
         } else {
 
@@ -32,8 +33,8 @@ public class ClientConnectionEvent {
             hostname = (server != null) ? server.getFolderName() : "sp_world";
         }
 
-        String hostname_old = "TCNodeTracker/" + Utils.invalidChars(hostname);
-        hostname = "TCNodeTracker/" + hostname;
+        String hostname_old = Constants.MODFOLDER + "/" + Utils.invalidChars(hostname);
+        hostname = Constants.MODFOLDER + "/" + hostname;
 
         File fileJson = new File(hostname);
         if (!fileJson.exists()) {

--- a/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
@@ -1,7 +1,10 @@
 package com.dyonovan.tcnodetracker.events;
 
-import java.io.File;
+import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -19,34 +22,34 @@ public class ClientConnectionEvent {
     @SubscribeEvent
     public void onConnected(FMLNetworkEvent.ClientConnectedToServerEvent event) {
 
-        String hostname;
+        String worldDir;
 
         if (!event.isLocal) {
-
             InetSocketAddress address = (InetSocketAddress) event.manager.getSocketAddress();
-            hostname = address.getHostName() + "_" + address.getPort();
-            hostname = Utils.invalidChars(hostname);
+            worldDir = Utils.invalidChars(address.getHostName() + "_" + address.getPort());
 
         } else {
-
             IntegratedServer server = Minecraft.getMinecraft().getIntegratedServer();
-            hostname = (server != null) ? server.getFolderName() : "sp_world";
+            worldDir = (server != null) ? server.getFolderName() : "sp_world";
         }
 
-        String hostname_old = Constants.MODFOLDER + "/" + Utils.invalidChars(hostname);
-        hostname = Constants.MODFOLDER + "/" + hostname;
+        Path storagePathRoot = Paths.get(Minecraft.getMinecraft().mcDataDir.getPath(), Constants.MODFOLDER);
+        Path storagePath = storagePathRoot.resolve(worldDir);
+        Path storagePath_old = storagePathRoot.resolve(Utils.invalidChars(worldDir));
 
-        File fileJson = new File(hostname);
-        if (!fileJson.exists()) {
-            File fileJsonOld = new File(hostname_old);
-            if (fileJsonOld.exists()) {
-                fileJsonOld.renameTo(fileJson);
-            } else {
-                fileJson.mkdirs();
+        if (Files.notExists(storagePath)) {
+            try {
+                if (Files.exists(storagePath_old)) {
+                    Files.move(storagePath_old, storagePath);
+                } else {
+                    Files.createDirectories(storagePath);
+                }
+            } catch (IOException e) {
+                TCNodeTracker.LOGGER.error("Failed to create or migrate node directory", e);
             }
         }
 
-        TCNodeTracker.hostName = hostname;
+        TCNodeTracker.jsonPath = storagePath.resolve("nodes.json");
         TCNodeTracker.nodelist.clear();
 
         JsonUtils.readJson();

--- a/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -33,7 +32,7 @@ public class ClientConnectionEvent {
             worldDir = (server != null) ? server.getFolderName() : "sp_world";
         }
 
-        Path storagePathRoot = Paths.get(Minecraft.getMinecraft().mcDataDir.getPath(), Constants.MODFOLDER);
+        Path storagePathRoot = (Minecraft.getMinecraft().mcDataDir.toPath()).resolve(Constants.MODFOLDER);
         Path storagePath = storagePathRoot.resolve(worldDir);
         Path storagePath_old = storagePathRoot.resolve(Utils.invalidChars(worldDir));
 

--- a/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/ClientConnectionEvent.java
@@ -51,6 +51,10 @@ public class ClientConnectionEvent {
         TCNodeTracker.jsonPath = storagePath.resolve("nodes.json");
         TCNodeTracker.nodelist.clear();
 
+        // Create empty JSON file if none exists yet to prevent log spam
+        if (Files.notExists(TCNodeTracker.jsonPath)) {
+            JsonUtils.writeJson();
+        }
         JsonUtils.readJson();
     }
 }

--- a/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
@@ -24,8 +24,9 @@ public class SaveDeletionEvent {
             try {
                 FileUtils.deleteDirectory(TCDataDir.toFile());
             } catch (IOException e) {
-                TCNodeTracker.LOGGER
-                        .warn(Constants.MODID + ": Failed to delete JourneyMap world data in {}", TCDataDir);
+                TCNodeTracker.LOGGER.warn(
+                        Constants.MODID + ": Failed to delete TCNodeTracker world data for world {}",
+                        event.worldName);
             }
         }
     }

--- a/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
@@ -1,0 +1,32 @@
+package com.dyonovan.tcnodetracker.events;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import net.minecraft.client.Minecraft;
+
+import org.apache.commons.io.FileUtils;
+
+import com.dyonovan.tcnodetracker.TCNodeTracker;
+import com.dyonovan.tcnodetracker.lib.Constants;
+import com.gtnewhorizon.gtnhlib.client.event.WorldDeletionEvent;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
+public class SaveDeletionEvent {
+
+    @SubscribeEvent
+    public void onWorldDeletionEvent(WorldDeletionEvent event) {
+        Path TCDataDir = Paths.get(Minecraft.getMinecraft().mcDataDir.getPath(), "TCNodeTracker", event.getWorldName());
+        if (Files.isDirectory(TCDataDir)) {
+            try {
+                FileUtils.deleteDirectory(TCDataDir.toFile());
+            } catch (IOException e) {
+                TCNodeTracker.LOGGER
+                        .warn(Constants.MODID + ": Failed to delete JourneyMap world data in {}", TCDataDir);
+            }
+        }
+    }
+}

--- a/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
@@ -19,7 +19,8 @@ public class SaveDeletionEvent {
 
     @SubscribeEvent
     public void onWorldDeletionEvent(WorldDeletionEvent event) {
-        Path TCDataDir = Paths.get(Minecraft.getMinecraft().mcDataDir.getPath(), "TCNodeTracker", event.getWorldName());
+        Path TCDataDir = Paths
+                .get(Minecraft.getMinecraft().mcDataDir.getPath(), Constants.MODFOLDER, event.getWorldName());
         if (Files.isDirectory(TCDataDir)) {
             try {
                 FileUtils.deleteDirectory(TCDataDir.toFile());

--- a/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/events/SaveDeletionEvent.java
@@ -19,8 +19,7 @@ public class SaveDeletionEvent {
 
     @SubscribeEvent
     public void onWorldDeletionEvent(WorldDeletionEvent event) {
-        Path TCDataDir = Paths
-                .get(Minecraft.getMinecraft().mcDataDir.getPath(), Constants.MODFOLDER, event.getWorldName());
+        Path TCDataDir = Paths.get(Minecraft.getMinecraft().mcDataDir.getPath(), Constants.MODFOLDER, event.worldName);
         if (Files.isDirectory(TCDataDir)) {
             try {
                 FileUtils.deleteDirectory(TCDataDir.toFile());

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/Constants.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/Constants.java
@@ -5,7 +5,7 @@ public class Constants {
     public static final String MODID = "tcnodetracker";
     public static final String MODNAME = "TC Node Tracker";
     public static final String MODFOLDER = "TCNodeTracker";
-    public static final String DEPENDENCIES = "required-after:Forge@[10.12.1.1112,);required-after:Thaumcraft;after:navigator";
+    public static final String DEPENDENCIES = "required-after:gtnhlib@[0.9.57,);required-after:Thaumcraft;after:navigator";
 
     public static final String AIR = "aer";
     public static final String EARTH = "terra";

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/Constants.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/Constants.java
@@ -4,6 +4,7 @@ public class Constants {
 
     public static final String MODID = "tcnodetracker";
     public static final String MODNAME = "TC Node Tracker";
+    public static final String MODFOLDER = "TCNodeTracker";
     public static final String DEPENDENCIES = "required-after:Forge@[10.12.1.1112,);required-after:Thaumcraft;after:navigator";
 
     public static final String AIR = "aer";

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
@@ -68,8 +68,7 @@ public class JsonUtils {
             fw.write(json);
             fw.close();
         } catch (IOException e) {
-            // e.printStackTrace();
-            System.out.println(Constants.MODID + ": Could not write to nodes.json!");
+            TCNodeTracker.LOGGER.error("Could not write to nodes.json");
         }
     }
 
@@ -86,8 +85,7 @@ public class JsonUtils {
                 writeJson();
             }
         } catch (FileNotFoundException e) {
-            // e.printStackTrace();
-            System.out.println(Constants.MODID + ": No nodes.json file found.");
+            TCNodeTracker.LOGGER.error("nodes.json file not found");
         }
     }
 }

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
@@ -63,10 +63,8 @@ public class JsonUtils {
                 .create();
         String json = gson.toJson(TCNodeTracker.nodelist);
 
-        try {
-            FileWriter fw = new FileWriter(TCNodeTracker.hostName + "/nodes.json");
+        try (FileWriter fw = new FileWriter(TCNodeTracker.jsonPath.toFile())) {
             fw.write(json);
-            fw.close();
         } catch (IOException e) {
             TCNodeTracker.LOGGER.error("Could not write to nodes.json");
         }
@@ -74,10 +72,8 @@ public class JsonUtils {
 
     public static void readJson() {
 
-        try {
-            BufferedReader br = new BufferedReader(new FileReader(TCNodeTracker.hostName + "/nodes.json"));
+        try (BufferedReader br = new BufferedReader(new FileReader(TCNodeTracker.jsonPath.toFile()))) {
             Gson gson = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantDeserializer()).create();
-            // TCNodeTracker.nodelist = gson.fromJson(br, TCNodeTracker.nodelist.getClass());
             needsSaving = false;
             TCNodeTracker.nodelist = gson.fromJson(br, new TypeToken<List<NodeList>>() {}.getType());
             if (needsSaving) {
@@ -85,7 +81,9 @@ public class JsonUtils {
                 writeJson();
             }
         } catch (FileNotFoundException e) {
-            TCNodeTracker.LOGGER.info("nodes.json file not found");
+            TCNodeTracker.LOGGER.debug("nodes.json not found, probably just not created yet");
+        } catch (IOException e) {
+            TCNodeTracker.LOGGER.error("Failed to read nodes.json", e);
         }
     }
 }

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
@@ -1,7 +1,6 @@
 package com.dyonovan.tcnodetracker.lib;
 
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -80,8 +79,6 @@ public class JsonUtils {
                 needsSaving = false;
                 writeJson();
             }
-        } catch (FileNotFoundException e) {
-            TCNodeTracker.LOGGER.debug("nodes.json not found, probably just not created yet");
         } catch (IOException e) {
             TCNodeTracker.LOGGER.error("Failed to read nodes.json", e);
         }

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
@@ -2,10 +2,10 @@ package com.dyonovan.tcnodetracker.lib;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -72,7 +72,7 @@ public class JsonUtils {
 
     public static void readJson() {
 
-        try (BufferedReader br = new BufferedReader(new FileReader(TCNodeTracker.jsonPath.toFile()))) {
+        try (BufferedReader br = Files.newBufferedReader(TCNodeTracker.jsonPath)) {
             Gson gson = new GsonBuilder().registerTypeAdapter(Instant.class, new InstantDeserializer()).create();
             needsSaving = false;
             TCNodeTracker.nodelist = gson.fromJson(br, new TypeToken<List<NodeList>>() {}.getType());

--- a/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
+++ b/src/main/java/com/dyonovan/tcnodetracker/lib/JsonUtils.java
@@ -85,7 +85,7 @@ public class JsonUtils {
                 writeJson();
             }
         } catch (FileNotFoundException e) {
-            TCNodeTracker.LOGGER.error("nodes.json file not found");
+            TCNodeTracker.LOGGER.info("nodes.json file not found");
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/GTNHLib/pull/338
Will also requiring adding GTNHLib as dependency.

Use introduced `WorldDeletionEvent` to delete TC data for that save, placed into `TCNodeTracker/<World Name>`.

